### PR TITLE
- 누적 당첨금 추가

### DIFF
--- a/custom_components/dh_lottery/client/dh_lotto_645.py
+++ b/custom_components/dh_lottery/client/dh_lotto_645.py
@@ -80,6 +80,12 @@ class DhLotto645:
         draw_date: str
 
     @dataclass
+    class accumulatedPrizeData:
+        """로또 당첨 정보를 나타내는 데이터 클래스입니다."""
+
+        accumulated_prize: int = 10000  # 총예치금
+
+    @dataclass
     class Slot:
         """로또 슬롯 정보를 나타내는 데이터 클래스입니다."""
 


### PR DESCRIPTION
- 누적 당첨금 추가

누적 당첨금 센서 추가
* 당첨금액을 찾을 수 있는 1년간의 당첨 내역의 금액을 누적하여 보여주도록 수정하였습니다.
* custom_components 수정은 처음이라 소스 코드가 많이 부족할 수 있습니다.

<img width="969" alt="스크린샷 2024-06-15 오후 3 46 44" src="https://github.com/stkang/ha-component-dh-lottery/assets/11520239/ca5c359e-8693-468e-9dee-ad19116c4a92">

