### PR TITLE
Update dh_lottery_client.py

### DIFF
--- a/custom_components/dh_lottery/client/dh_lottery_client.py
+++ b/custom_components/dh_lottery/client/dh_lottery_client.py
@@ -179,6 +179,7 @@ class DhLotteryClient:
         await self.async_get_with_login("myPage.do?method=lottoBuyListView")
         now_page: int = 1
         accum_prize: int = 0
+        last_round_no: int = 0
         try:
             while True:
                 resp = await self.session.post(
@@ -203,6 +204,11 @@ class DhLotteryClient:
                     tds = tr.select("td")
                     if tds[5].text.strip() not in ("당첨", "낙첨", "미추첨"):
                         return accum_prize
+
+                    if last_round_no <= int(tds[2].text.strip()) and now_page > 1:
+                        return accum_prize
+
+                    last_round_no = int(tds[2].text.strip())
                     accum_prize += DhLotteryClient.parse_digit(tds[6].text.strip())
                 if len(trs) < 10:
                     return accum_prize


### PR DESCRIPTION
last_round_no 용도
- 당첨금액 내역이 10개가 될 경우 무한 루프에 빠질 위험성 존재
- 회차는 내림차순으로 정렬되어있어 다음번 값이 이전 값보다 크거나 같을 수 없음