### PR TITLE
fix: forwarded platform sensor에서 ConfigEntryNotReady 예외 발생 문제 해결

### DIFF
--- a/custom_components/dh_lottery/__init__.py
+++ b/custom_components/dh_lottery/__init__.py
@@ -66,10 +66,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: DhLotteryConfigEntry) ->
         raise ConfigEntryNotReady(f"동행 복권 로그인 실패: {ex}") from ex
 
     data = DhLotteryData(DhLotteryCoordinator(hass, client))
+
+    # 센서 플랫폼 설정 전에 coordinator 첫 새로고침 수행
+    try:
+        await data.lottery_coord.async_config_entry_first_refresh()
+    except Exception as ex:
+        raise ConfigEntryNotReady(f"예치금 정보 조회 실패: {ex}") from ex
+
     if entry.data[CONF_LOTTO_645]:
         data.lotto_645_coord = DhLotto645Coordinator(
             hass, client, data.lottery_coord.async_clear_refresh
         )
+        try:
+            await data.lotto_645_coord.async_config_entry_first_refresh()
+        except Exception as ex:
+            raise ConfigEntryNotReady(f"로또 정보 조회 실패: {ex}") from ex
+
     entry.runtime_data = data
     hass.data[DOMAIN][entry.entry_id] = data
 

--- a/custom_components/dh_lottery/sensor.py
+++ b/custom_components/dh_lottery/sensor.py
@@ -36,14 +36,12 @@ async def async_setup_entry(
     """설정 항목을 사용하여 센서 엔티티를 추가합니다."""
     data: DhLotteryData = entry.runtime_data
 
-    await data.lottery_coord.async_config_entry_first_refresh()
+    # __init__.py에서 이미 async_config_entry_first_refresh() 호출됨
     entities: List[Entity] = [
         DhDepositSensor(data.lottery_coord),
         DhAccumulatedPrizeSensor(data.lottery_coord),
     ]
     if entry.data[CONF_LOTTO_645]:
-        await data.lotto_645_coord.async_config_entry_first_refresh()
-
         entities.append(DhLotto645WinningSensor(data.lotto_645_coord))
         for i in range(1, 6):
             entities.append(DhLotto645HistorySensor(data.lotto_645_coord, i))


### PR DESCRIPTION
- async_config_entry_first_refresh()를 async_forward_entry_setups() 호출 전 __init__.py로 이동
- sensor.py에서 중복 refresh 호출 제거
- HA 가이드라인에 따라 플랫폼 설정 전에 ConfigEntryNotReady 예외 발생하도록 수정

수정된 오류: "raises exception ConfigEntryNotReady in forwarded platform sensor"